### PR TITLE
Reset the python interpreter to the original

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set a fact about the Ansible python interpreter
+  set_fact:
+    old_ansible_python_interpreter: "{{ ansible_python_interpreter | default('/usr/bin/python') }}"
+
 # Note that setting this via a play or task variable seems to not
 # evaluate the Jinja variable reference, so we use set_fact.
 - name: Update the Ansible python interpreter fact to point to the virtualenv
@@ -55,4 +59,4 @@
 # possible to unset a variable in Ansible.
 - name: Set a fact to reset the Ansible python interpreter
   set_fact:
-    ansible_python_interpreter: /usr/bin/python
+    ansible_python_interpreter: "{{ old_ansible_python_interpreter }}"


### PR DESCRIPTION
Previously, if the role was used with ansible_python_interpreter set,
the variable would be set to /usr/bin/python at the end of role
execution. This change stores the original interpreter and resets it
appropriately.