### PR TITLE
Support OpenStack deployments requiring OS_CACERT to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Role Variables
 `os_networks_auth` is a dict containing authentication information
 compatible with the `auth` argument of `os_*` Ansible modules.
 
+`os_networks_environment` is a dict containing OpenStack environment variables
+to pass to the `os_*` Ansible modules.
+
 `os_networks` is a list of networks to register. Each item should be a
 dict containing the following items:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ os_networks_auth: {}
 
 # OpenStack environment variables to pass to the 'os_network' Ansible module.
 os_networks_environment:
+  OS_CACERT: "{{ lookup('env', 'OS_CACERT') }}"
   OS_IDENTITY_API_VERSION: 3
 
 # List of networks to create. Each item should be a dict containing the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ os_networks_auth_type:
 # auth argument.
 os_networks_auth: {}
 
+# OpenStack environment variables to pass to the 'os_network' Ansible module.
+os_networks_environment:
+  OS_IDENTITY_API_VERSION: 3
+
 # List of networks to create. Each item should be a dict containing the
 # following items:
 # - 'name': Name of the neutron network.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,8 +22,7 @@
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ os_networks }}"
-  environment:
-    OS_IDENTITY_API_VERSION: 3
+  environment: "{{ os_networks_environment }}"
 
 - name: Ensure subnet is registered with neutron
   os_subnet:
@@ -47,8 +46,7 @@
   with_subelements:
     - "{{ os_networks }}"
     - subnets
-  environment:
-    OS_IDENTITY_API_VERSION: 3
+  environment: "{{ os_networks_environment }}"
 
 - name: Ensure router is registered with neutron
   os_router:
@@ -60,8 +58,7 @@
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ os_networks_routers }}"
-  environment:
-    OS_IDENTITY_API_VERSION: 3
+  environment: "{{ os_networks_environment }}"
 
 - name: Ensure security groups are registered with neutron
   os_security_group:
@@ -72,8 +69,7 @@
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
   with_items: "{{ os_networks_security_groups }}"
-  environment:
-    OS_IDENTITY_API_VERSION: 3
+  environment: "{{ os_networks_environment }}"
 
 - name: Ensure security group rules are registered with neutron
   os_security_group_rule:
@@ -92,8 +88,7 @@
   with_subelements:
     - "{{ os_networks_security_groups }}"
     - rules
-  environment:
-    OS_IDENTITY_API_VERSION: 3
+  environment: "{{ os_networks_environment }}"
 
 # This variable is unset before we set it, and it does not appear to be
 # possible to unset a variable in Ansible.


### PR DESCRIPTION
OpenStack deployments using a TLS certificate from a CA untrusted by the system need the OS_CACERT environment variable to be defined.