### PR TITLE
Allow customizing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ compatible with the `auth` argument of `os_*` Ansible modules.
 
 `os_networks_cloud` is an optional name of a cloud in `clouds.yaml`.
 
+`os_networks_interface` is the endpoint URL type to fetch from the service
+catalog. Maybe be one of `public`, `admin`, or `internal`.
+
 `os_networks` is a list of networks to register. Each item should be a
 dict containing the following items:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,13 +6,13 @@ os_networks_venv:
 # auth_type argument.
 os_networks_auth_type:
 
-# Endpoint URL type to fetch from the service catalog. Maybe be one of:
-# public, admin, or internal.
-os_networks_interface:
-
 # Authentication parameters compatible with the 'os_network' Ansible module's
 # auth argument.
 os_networks_auth: {}
+
+# Endpoint URL type to fetch from the service catalog. Maybe be one of:
+# public, admin, or internal.
+os_networks_interface:
 
 # List of networks to create. Each item should be a dict containing the
 # following items:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,10 @@ os_networks_venv:
 # auth_type argument.
 os_networks_auth_type:
 
+# Endpoint URL type to fetch from the service catalog. Maybe be one of:
+# public, admin, or internal.
+os_networks_interface:
+
 # Authentication parameters compatible with the 'os_network' Ansible module's
 # auth argument.
 os_networks_auth: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,9 @@
   os_router:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
@@ -28,9 +28,9 @@
   os_network:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     provider_network_type: "{{ item.provider_network_type | default(omit) }}"
     provider_physical_network: "{{ item.provider_physical_network | default(omit) }}"
@@ -47,9 +47,9 @@
   os_subnet:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.1.name }}"
     network_name: "{{ item.0.name }}"
     cidr: "{{ item.1.cidr | default(omit) }}"
@@ -77,10 +77,10 @@
 - name: Ensure router is registered with neutron
   os_router:
     auth_type: "{{ os_networks_auth_type }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     interfaces: "{{ item.interfaces | default(omit) }}"
     network: "{{ item.network | default(omit) }}"
@@ -94,10 +94,10 @@
 - name: Ensure security groups are registered with neutron
   os_security_group:
     auth_type: "{{ os_networks_auth_type }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     name: "{{ item.name }}"
     description: "{{ item.description | default(omit) }}"
     project: "{{ item.project | default(omit) }}"
@@ -109,10 +109,10 @@
 - name: Ensure security group rules are registered with neutron
   os_security_group_rule:
     auth_type: "{{ os_networks_auth_type }}"
-    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     direction: "{{ item.1.direction | default(omit) }}"
     ethertype: "{{ item.1.ethertype | default(omit) }}"
     port_range_min: "{{ item.1.port_range_min | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
   os_router:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
     name: "{{ item.name }}"
@@ -27,6 +28,7 @@
   os_network:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
     name: "{{ item.name }}"
@@ -45,6 +47,7 @@
   os_subnet:
     auth_type: "{{ os_networks_auth_type }}"
     auth: "{{ os_networks_auth }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
     name: "{{ item.1.name }}"
@@ -74,6 +77,7 @@
 - name: Ensure router is registered with neutron
   os_router:
     auth_type: "{{ os_networks_auth_type }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
@@ -90,6 +94,7 @@
 - name: Ensure security groups are registered with neutron
   os_security_group:
     auth_type: "{{ os_networks_auth_type }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"
@@ -104,6 +109,7 @@
 - name: Ensure security group rules are registered with neutron
   os_security_group_rule:
     auth_type: "{{ os_networks_auth_type }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
     auth: "{{ os_networks_auth }}"
     cacert: "{{ os_networks_cacert | default(omit) }}"
     cloud: "{{ os_networks_cloud | default(omit) }}"


### PR DESCRIPTION
Most of the os_ ansible modules take an interface or endpoint_type parameter. This adds interface as a configurable parameter as it is most similar to OS_INTERFACE environment variable.