### PR TITLE
Don't pass empty string as segmentation id

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     name: "{{ item.name }}"
     provider_network_type: "{{ item.provider_network_type | default(omit) }}"
     provider_physical_network: "{{ item.provider_physical_network | default(omit) }}"
-    provider_segmentation_id: "{{ item.provider_segmentation_id | default(omit) }}"
+    provider_segmentation_id: "{{ item.provider_segmentation_id | default(omit, true) }}"
     shared: "{{ item.shared | default(omit) }}"
     external: "{{ item.external | default(omit) }}"
     project: "{{ item.project | default(omit) }}"


### PR DESCRIPTION
Example of failure:

```
    "item": {
        "name": "provision-net",
        "provider_network_type": "flat",
        "provider_physical_network": "physnet1",
        "provider_segmentation_id": "",
        "shared": true,
        "subnets": [
            {
                "allocation_pool_end": "192.168.33.127",
                "allocation_pool_start": "192.168.33.31",
                "cidr": "192.168.33.0/24",
                "gateway_ip": "",
                "name": "provision-net"
            }
        ]
    },
    "msg": "argument provider_segmentation_id is of type <type 'str'> and we were unable to convert to int: <type 'str'> cannot be converted to an int"
```

See: https://zuul.opendev.org/t/openstack/build/d7ccaf88ecc94d2284637438a5ed306c/log/primary/ansible/overcloud-deploy#100416

This occurs with ansible >= 2.8. Previously this seemed to valid.

This change allows you to use the empty string for convenience, otherwise you would have filter the dictionary keys to selectively pass it through.