### PR TITLE
Remove stray colons

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,8 +40,8 @@
     project: "{{ item.project | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     mtu: "{{ item.mtu | default(omit) }}"
-    dns_domain: "{{ item.dns_domain: | default(omit) }}"
-    port_security_enabled: "{{ item.port_security_enabled: | default(omit) }}"
+    dns_domain: "{{ item.dns_domain | default(omit) }}"
+    port_security_enabled: "{{ item.port_security_enabled | default(omit) }}"
   with_items: "{{ os_networks }}"
   environment:
     OS_IDENTITY_API_VERSION: 3


### PR DESCRIPTION
This was causing errors like:

```
TASK [stackhpc.os-networks : Ensure network is registered with neutron] ********
task path: /home/zuul/kayobe-venv/share/kayobe/ansible/roles/stackhpc.os-networks/tasks/main.yml:27
fatal: [controller0]: FAILED! => {
    "msg": "template error while templating string: expected token 'end of print statement', got ':'. String: {{ item.dns_domain: | default(omit) }}"
}
```