### PR TITLE
Switch from os-shade to os-openstacksdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ln -s $(pwd) ../stackhpc.os-networks
 
   # Install role dependencies
-  - ansible-galaxy install -p .. stackhpc.os-shade
+  - ansible-galaxy install -p .. stackhpc.os_openstacksdk
 
 script:
   # Run Ansible lint against the role

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Each item should be a dict containing the following items:
 Dependencies
 ------------
 
-This role depends on the `stackhpc.os-shade` role.
+This role depends on the `stackhpc.os-openstacksdk` role.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Each item should be a dict containing the following items:
 Dependencies
 ------------
 
-This role depends on the `stackhpc.os-openstacksdk` role.
+This role depends on the `stackhpc.os_openstacksdk` role.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Path to virtualenv in which to install shade and its dependencies.
+# Path to virtualenv in which to install openstacksdk and its dependencies.
 os_networks_venv:
 
 # Authentication type compatible with the 'os_network' Ansible module's

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,5 +17,5 @@ galaxy_info:
     - openstack
 
 dependencies:
-  - role: stackhpc.os-shade
-    os_shade_venv: "{{ os_networks_venv }}"
+  - role: stackhpc.os_openstacksdk
+    os_openstacksdk_venv: "{{ os_networks_venv }}"


### PR DESCRIPTION
Shade is no longer required by ansible modules.