### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,4 +88,4 @@ os_networks_security_groups: []
 #
 # Use Victoria upper constraints otherwise, due to a bug in openstacksdk 0.53:
 # https://storyboard.openstack.org/#!/story/2008577
-os_networks_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_python.version.major == 2 %}train{% else %}victoria{% endif %}"
+os_networks_upper_constraints_file: "https://releases.openstack.org/constraints/upper/{% if ansible_facts.python.version.major == 2 %}train{% else %}victoria{% endif %}"


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts..

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars