### PR TITLE
CI: Update versions used of community GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Installing dependencies
         run: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Installing dependencies
         run: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- import_tasks: networks.yml
+- name: Import networks.yml
+  ansible.builtin.import_tasks: networks.yml
   vars:
     ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"
   environment:


### PR DESCRIPTION
DEV-1359

Syncing the versions of community actions used to the latest major version.

This should avoid deprecation warnings seen in GitHub Actions.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
