### PR TITLE
Add support for Neutron RBAC sharing of networks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+skip_list:
+  # Computed fully qualified role name of role-os-networks does not follow current galaxy requirements.
+  - role-name

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Installing dependencies
         run: |
-          pip install "ansible-lint[community]"
+          pip install "ansible-lint[community]==5.*"
           printf '[defaults]\nroles_path=../' >ansible.cfg
           ln -s $(pwd) ../stackhpc.os-networks
           ansible-galaxy role install -p .. stackhpc.os_openstacksdk

--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ Each item should be a dict containing the following items:
   - `remote_ip_prefix`: Optional source IP address prefix in CIDR notation.
   - `state`: Optional state of the rule, default is `present`.
 
+`os_networks_rbac` is a list of role-based access control
+shares for named networks and projects.  See the [Neutron RBAC admin
+guide](https://docs.openstack.org/neutron/latest/admin/config-rbac.html#sharing-a-network-with-specific-projects)
+for details. Each entry in the list is a dictionary containing the
+following items:
+
+- `network`: The name of the network to share. This netowrk is normally
+  owned by the `admin` project and not `shared` or `external`.
+- `access`: The mode of sharing with the target project(s). Valid options
+  are `access_as_external` and `access_as_shared`
+- `projects`: A list of project names for sharing the named network
+  in the designated way.
+
+*NOTE*: RBAC assignments cannot be modified after they are created.
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ guide](https://docs.openstack.org/neutron/latest/admin/config-rbac.html#sharing-
 for details. Each entry in the list is a dictionary containing the
 following items:
 
-- `network`: The name of the network to share. This netowrk is normally
+- `network`: The name of the network to share. This network is normally
   owned by the `admin` project and not `shared` or `external`.
 - `access`: The mode of sharing with the target project(s). Valid options
   are `access_as_external` and `access_as_shared`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,19 @@ os_networks_routers: []
 #   - 'state': Optional state of the rule, default is 'present'.
 os_networks_security_groups: []
 
+# Role-Based Access Control (RBAC)
+# List of role-based access control shares for named networks and projects.
+# See https://docs.openstack.org/neutron/latest/admin/config-rbac.html
+# for details. Each entry in the list is a dictionary containing the
+# following items:
+# - `network`: The name of the network to share. This netowrk is normally
+#   owned by the `admin` project and not `shared` or `external`.
+# - `access`: The mode of sharing with the target project(s). Valid options
+#   are `access_as_external` and `access_as_shared`
+# - `projects`: A list of project names for sharing the named network
+#   in the designated way.
+os_networks_rbac: []
+
 # Use Train upper constraints when running with Python 2, to avoid
 # incompatibility with newer OSC releases.
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,7 +93,7 @@ os_networks_security_groups: []
 # See https://docs.openstack.org/neutron/latest/admin/config-rbac.html
 # for details. Each entry in the list is a dictionary containing the
 # following items:
-# - `network`: The name of the network to share. This netowrk is normally
+# - `network`: The name of the network to share. This network is normally
 #   owned by the `admin` project and not `shared` or `external`.
 # - `access`: The mode of sharing with the target project(s). Valid options
 #   are `access_as_external` and `access_as_shared`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     OS_IDENTITY_API_VERSION: 3
 
 - name: Import rbac.yml
-  ansible.builtin.import_tasks: rbac.yml
+  ansible.builtin.include_tasks: rbac.yml
   when: os_networks_rbac | length > 0
   vars:
     ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,3 @@
     ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"
   environment:
     OS_IDENTITY_API_VERSION: 3
-
-- name: Import rbac.yml
-  ansible.builtin.include_tasks: rbac.yml
-  when: os_networks_rbac | length > 0
-  vars:
-    ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"
-  environment:
-    OS_IDENTITY_API_VERSION: 3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,11 @@
     ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"
   environment:
     OS_IDENTITY_API_VERSION: 3
+
+- name: Import rbac.yml
+  ansible.builtin.import_tasks: rbac.yml
+  when: os_networks_rbac | length > 0
+  vars:
+    ansible_python_interpreter: "{{ os_networks_venv }}/bin/python"
+  environment:
+    OS_IDENTITY_API_VERSION: 3

--- a/tasks/networks.yml
+++ b/tasks/networks.yml
@@ -111,3 +111,7 @@
   with_subelements:
     - "{{ os_networks_security_groups }}"
     - rules
+
+- name: Include rbac.yml
+  ansible.builtin.include_tasks: rbac.yml
+  when: os_networks_rbac | length > 0

--- a/tasks/rbac.yml
+++ b/tasks/rbac.yml
@@ -1,0 +1,71 @@
+---
+
+# openstack.cloud.neutron_rbac_policy requires IDs for networks and projects.
+# We need to do some manipulation to extract the relevant data.
+
+# We assume all networks being shared by RBAC are owned by the admin project.
+- name: Gather details on admin networks for RBAC assignment
+  openstack.cloud.networks_info:
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
+  register: os_networks_admin_networks
+
+- name: Frobnicate to inject project ID
+  set_fact:
+    os_networks_rbac_with_id: "{{ os_networks_rbac_with_id + [ item | combine( {'network_id': os_networks_admin_networks.openstack_networks | selectattr('name', 'equalto', item['network'] ) | map(attribute='id') | first } ) ] }}"
+  with_items: "{{ os_networks_rbac }}"
+  vars:
+    os_networks_rbac_with_id: []
+
+# Retrieve admin project id
+# For some reason this project must be retrieved explicitly
+- name: Lookup OpenStack admin project data
+  openstack.cloud.project_info:
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
+    name: "admin"
+  register: admin_project_data
+
+- name: Set admin project ID
+  set_fact:
+    admin_project_id: "{{ admin_project_data.openstack_projects | map(attribute='id') | first }}"
+
+# Retrieve project IDs of other OpenStack projects
+- name: Lookup OpenStack project IDs
+  openstack.cloud.project_info:
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
+  register: project_data
+
+# Construct the exploded list pairing projects and RBAC assignments
+- name: Expand the project list for each RBAC policy
+  set_fact:
+    os_networks_rbac_expanded: "{{ os_networks_rbac_expanded + [item] | product(item['projects']) }}"
+  with_items: "{{ os_networks_rbac_with_id }}"
+  vars:
+    os_networks_rbac_expanded: []
+
+# Apply RBAC policies
+- name: Ensure neutron RBAC policies are implemented
+  openstack.cloud.neutron_rbac_policy:
+    auth_type: "{{ os_networks_auth_type }}"
+    auth: "{{ os_networks_auth }}"
+    cacert: "{{ os_networks_cacert | default(omit) }}"
+    cloud: "{{ os_networks_cloud | default(omit) }}"
+    interface: "{{ os_networks_interface | default(omit, true) }}"
+    action: "{{ item[0].access }}"
+    object_id: "{{ item[0].network_id }}"
+    object_type: "network"
+    project_id: "{{ admin_project_id }}"
+    target_project_id: "{{ project_data.openstack_projects | selectattr('name', 'equalto', item[1]) | map(attribute='id') | first }}"
+  loop: "{{ os_networks_rbac_expanded }}"
+


### PR DESCRIPTION
Networks that will be shared by Neutron RBAC are assumed to be
owned by the admin project and private to that project.
Such networks can be shared with a list of projects either in
"access_as_external" or "access_as_shared" mode.

The RBAC assignments cannot be modified once they have been created.